### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 ## bigstatsr 0.3.0
 
-- **Package {bigstatsr} is published in [Bioinformatics](http://dx.doi.org/10.1093/bioinformatics/bty185)**
+- **Package {bigstatsr} is published in [Bioinformatics](https://doi.org/10.1093/bioinformatics/bty185)**
 
 ## bigstatsr 0.2.6
 

--- a/R/biglasso.R
+++ b/R/biglasso.R
@@ -365,7 +365,7 @@ COPY_biglasso_main <- function(X, y.train, ind.train, ind.col, covar.train,
 #' Strong rules for discarding predictors in lasso-type problems.
 #' Journal of the Royal Statistical Society:
 #' Series B (Statistical Methodology), 74: 245–266.
-#' \url{http://dx.doi.org/10.1111/j.1467-9868.2011.01004.x}.
+#' \url{https://doi.org/10.1111/j.1467-9868.2011.01004.x}.
 #'
 #' Zeng, Y., and Breheny, P. (2016). The biglasso Package: A Memory- and
 #' Computation-Efficient Solver for Lasso Model Fitting with Big Data in R.

--- a/R/randomSVD.R
+++ b/R/randomSVD.R
@@ -153,7 +153,7 @@ svds4.seq <- function(X, fun.scaling, ind.row, ind.col, k, tol, verbose) {
 #' in Rokhlin, V., Szlam, A., & Tygert, M. (2010).
 #' A Randomized Algorithm for Principal Component Analysis.
 #' SIAM Journal on Matrix Analysis and Applications, 31(3), 1100–1124.
-#' \url{http://dx.doi.org/10.1137/080736417}.
+#' \url{https://doi.org/10.1137/080736417}.
 #'
 #' @inheritParams bigstatsr-package
 #' @param k Number of singular vectors/values to compute. Default is `10`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/privefl/bigstatsr?branch=master&svg=true)](https://ci.appveyor.com/project/privefl/bigstatsr)
 [![Coverage Status](https://img.shields.io/codecov/c/github/privefl/bigstatsr/master.svg)](https://codecov.io/github/privefl/bigstatsr?branch=master)
 [![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/bigstatsr)](https://cran.r-project.org/package=bigstatsr)
-[![DOI](https://zenodo.org/badge/doi/10.1093/bioinformatics/bty185.svg)](http://dx.doi.org/10.1093/bioinformatics/bty185)
+[![DOI](https://zenodo.org/badge/doi/10.1093/bioinformatics/bty185.svg)](https://doi.org/10.1093/bioinformatics/bty185)
 
 
 # bigstatsr

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -125,7 +125,7 @@
     <p>Privé F, Aschard H, Ziyatdinov A and Blum MG (2018).
 &ldquo;Efficient analysis of large-scale genome-wide data with two R packages: bigstatsr and bigsnpr.&rdquo;
 <em>Bioinformatics</em>.
-doi: <a href="http://doi.org/10.1093/bioinformatics/bty185">10.1093/bioinformatics/bty185</a>, <a href="http://dx.doi.org/10.1093/bioinformatics/bty185">http://dx.doi.org/10.1093/bioinformatics/bty185</a>. 
+doi: <a href="https://doi.org/10.1093/bioinformatics/bty185">10.1093/bioinformatics/bty185</a>, <a href="https://doi.org/10.1093/bioinformatics/bty185">https://doi.org/10.1093/bioinformatics/bty185</a>. 
 </p>
     <pre>@Article{,
   title = {Efficient analysis of large-scale genome-wide data with two R packages: bigstatsr and bigsnpr},
@@ -134,7 +134,7 @@ doi: <a href="http://doi.org/10.1093/bioinformatics/bty185">10.1093/bioinformati
   year = {2018},
   publisher = {Oxford University Press},
   doi = {10.1093/bioinformatics/bty185},
-  url = {http://dx.doi.org/10.1093/bioinformatics/bty185},
+  url = {https://doi.org/10.1093/bioinformatics/bty185},
 }</pre>
     <div class="page-header">
       <h1>Authors</h1>

--- a/docs/index.html
+++ b/docs/index.html
@@ -184,7 +184,7 @@ devtools<span class="op">::</span><span class="kw"><a href="http://www.rdocument
 <li><a href="https://ci.appveyor.com/project/privefl/bigstatsr"><img src="https://ci.appveyor.com/api/projects/status/github/privefl/bigstatsr?branch=master&amp;svg=true" alt="AppVeyor Build Status"></a></li>
 <li><a href="https://codecov.io/github/privefl/bigstatsr?branch=master"><img src="https://img.shields.io/codecov/c/github/privefl/bigstatsr/master.svg" alt="Coverage Status"></a></li>
 <li><a href="https://cran.r-project.org/package=bigstatsr"><img src="http://www.r-pkg.org/badges/version/bigstatsr" alt="CRAN_Status_Badge"></a></li>
-<li><a href="http://dx.doi.org/10.1093/bioinformatics/bty185"><img src="https://zenodo.org/badge/doi/10.1093/bioinformatics/bty185.svg" alt="DOI"></a></li>
+<li><a href="https://doi.org/10.1093/bioinformatics/bty185"><img src="https://zenodo.org/badge/doi/10.1093/bioinformatics/bty185.svg" alt="DOI"></a></li>
 </ul>
 </div>
 </div>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -134,7 +134,7 @@
 <h2 class="hasAnchor">
 <a href="#bigstatsr-0-3-0" class="anchor"></a>bigstatsr 0.3.0</h2>
 <ul>
-<li><strong>Package {bigstatsr} is published in <a href="http://dx.doi.org/10.1093/bioinformatics/bty185">Bioinformatics</a></strong></li>
+<li><strong>Package {bigstatsr} is published in <a href="https://doi.org/10.1093/bioinformatics/bty185">Bioinformatics</a></strong></li>
 </ul>
 </div>
     <div id="bigstatsr-0-2-6" class="section level2">

--- a/docs/reference/big_randomSVD.html
+++ b/docs/reference/big_randomSVD.html
@@ -215,7 +215,7 @@ It proved to be faster than our implementation of the "blanczos" algorithm
 in Rokhlin, V., Szlam, A., &amp; Tygert, M. (2010).
 A Randomized Algorithm for Principal Component Analysis.
 SIAM Journal on Matrix Analysis and Applications, 31(3), 1100–1124.
-<a href='http://dx.doi.org/10.1137/080736417'>http://dx.doi.org/10.1137/080736417</a>.</p>
+<a href='https://doi.org/10.1137/080736417'>https://doi.org/10.1137/080736417</a>.</p>
     
     <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>
 

--- a/docs/reference/big_spLinReg.html
+++ b/docs/reference/big_spLinReg.html
@@ -245,7 +245,7 @@ Simon, N., Taylor, J. and Tibshirani, R. J. (2012),
 Strong rules for discarding predictors in lasso-type problems.
 Journal of the Royal Statistical Society:
 Series B (Statistical Methodology), 74: 245–266.
-<a href='http://dx.doi.org/10.1111/j.1467-9868.2011.01004.x'>http://dx.doi.org/10.1111/j.1467-9868.2011.01004.x</a>.</p>
+<a href='https://doi.org/10.1111/j.1467-9868.2011.01004.x'>https://doi.org/10.1111/j.1467-9868.2011.01004.x</a>.</p>
 <p>Zeng, Y., and Breheny, P. (2016). The biglasso Package: A Memory- and
 Computation-Efficient Solver for Lasso Model Fitting with Big Data in R.
 arXiv preprint arXiv:1701.05936. <a href='https://arxiv.org/abs/1701.05936'>https://arxiv.org/abs/1701.05936</a>.</p>

--- a/docs/reference/big_spLogReg.html
+++ b/docs/reference/big_spLogReg.html
@@ -244,7 +244,7 @@ Simon, N., Taylor, J. and Tibshirani, R. J. (2012),
 Strong rules for discarding predictors in lasso-type problems.
 Journal of the Royal Statistical Society:
 Series B (Statistical Methodology), 74: 245–266.
-<a href='http://dx.doi.org/10.1111/j.1467-9868.2011.01004.x'>http://dx.doi.org/10.1111/j.1467-9868.2011.01004.x</a>.</p>
+<a href='https://doi.org/10.1111/j.1467-9868.2011.01004.x'>https://doi.org/10.1111/j.1467-9868.2011.01004.x</a>.</p>
 <p>Zeng, Y., and Breheny, P. (2016). The biglasso Package: A Memory- and
 Computation-Efficient Solver for Lasso Model Fitting with Big Data in R.
 arXiv preprint arXiv:1701.05936. <a href='https://arxiv.org/abs/1701.05936'>https://arxiv.org/abs/1701.05936</a>.</p>

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -7,6 +7,6 @@ citEntry(entry = "Article",
   year="2018",
   publisher="Oxford University Press",
   doi = "10.1093/bioinformatics/bty185",
-  url = "http://dx.doi.org/10.1093/bioinformatics/bty185",
+  url = "https://doi.org/10.1093/bioinformatics/bty185",
   textVersion='Privé, Florian, et al. "Efficient analysis of large-scale genome-wide data with two R packages: bigstatsr and bigsnpr." Bioinformatics (2018).'
 )

--- a/man/big_randomSVD.Rd
+++ b/man/big_randomSVD.Rd
@@ -65,7 +65,7 @@ It proved to be faster than our implementation of the "blanczos" algorithm
 in Rokhlin, V., Szlam, A., & Tygert, M. (2010).
 A Randomized Algorithm for Principal Component Analysis.
 SIAM Journal on Matrix Analysis and Applications, 31(3), 1100–1124.
-\url{http://dx.doi.org/10.1137/080736417}.
+\url{https://doi.org/10.1137/080736417}.
 }
 \examples{
 set.seed(1)

--- a/man/big_spLinReg.Rd
+++ b/man/big_spLinReg.Rd
@@ -125,7 +125,7 @@ Simon, N., Taylor, J. and Tibshirani, R. J. (2012),
 Strong rules for discarding predictors in lasso-type problems.
 Journal of the Royal Statistical Society:
 Series B (Statistical Methodology), 74: 245–266.
-\url{http://dx.doi.org/10.1111/j.1467-9868.2011.01004.x}.
+\url{https://doi.org/10.1111/j.1467-9868.2011.01004.x}.
 
 Zeng, Y., and Breheny, P. (2016). The biglasso Package: A Memory- and
 Computation-Efficient Solver for Lasso Model Fitting with Big Data in R.

--- a/man/big_spLogReg.Rd
+++ b/man/big_spLogReg.Rd
@@ -128,7 +128,7 @@ Simon, N., Taylor, J. and Tibshirani, R. J. (2012),
 Strong rules for discarding predictors in lasso-type problems.
 Journal of the Royal Statistical Society:
 Series B (Statistical Methodology), 74: 245–266.
-\url{http://dx.doi.org/10.1111/j.1467-9868.2011.01004.x}.
+\url{https://doi.org/10.1111/j.1467-9868.2011.01004.x}.
 
 Zeng, Y., and Breheny, P. (2016). The biglasso Package: A Memory- and
 Computation-Efficient Solver for Lasso Model Fitting with Big Data in R.

--- a/tmp-save/AUC.R
+++ b/tmp-save/AUC.R
@@ -29,11 +29,11 @@
 #' The meaning and use of the area under a
 #' receiver operating characteristic (ROC) curve.
 #' Radiology, 143(1), 29-36.
-#' \url{http://dx.doi.org/10.1148/radiology.143.1.7063747}.
+#' \url{https://doi.org/10.1148/radiology.143.1.7063747}.
 #'
 #' Tom Fawcett. 2006. An introduction to ROC analysis.
 #' Pattern Recogn. Lett. 27, 8 (June 2006), 861-874.
-#' \url{http://dx.doi.org/10.1016/j.patrec.2005.10.010}.
+#' \url{https://doi.org/10.1016/j.patrec.2005.10.010}.
 #'
 #' @seealso [wilcox.test]
 #' @examples

--- a/tmp-save/biglasso.R
+++ b/tmp-save/biglasso.R
@@ -30,7 +30,7 @@ check_biglasso <- function() {
 #' Strong rules for discarding predictors in lasso-type problems.
 #' Journal of the Royal Statistical Society:
 #' Series B (Statistical Methodology), 74: 245–266.
-#' \url{http://dx.doi.org/10.1111/j.1467-9868.2011.01004.x}.
+#' \url{https://doi.org/10.1111/j.1467-9868.2011.01004.x}.
 #'
 #' @export
 big_spRegLin <- function(X, y.train, ind.train = seq(nrow(X)),

--- a/tmp-save/biglasso/biglasso.R
+++ b/tmp-save/biglasso/biglasso.R
@@ -261,7 +261,7 @@ COPY_biglasso <- function(X, y.train, ind.train, covar.train,
 #' Strong rules for discarding predictors in lasso-type problems.
 #' Journal of the Royal Statistical Society:
 #' Series B (Statistical Methodology), 74: 245–266.
-#' \url{http://dx.doi.org/10.1111/j.1467-9868.2011.01004.x}.
+#' \url{https://doi.org/10.1111/j.1467-9868.2011.01004.x}.
 #'
 #' Zeng, Y., and Breheny, P. (2016). The biglasso Package: A Memory- and
 #' Computation-Efficient Solver for Lasso Model Fitting with Big Data in R.

--- a/tmp-save/randomSVD-reverse.R
+++ b/tmp-save/randomSVD-reverse.R
@@ -167,7 +167,7 @@ svds4.seq <- function(X., fun.scaling, ind.row, ind.col, k, tol, verbose) {
 #' in Rokhlin, V., Szlam, A., & Tygert, M. (2010).
 #' A Randomized Algorithm for Principal Component Analysis.
 #' SIAM Journal on Matrix Analysis and Applications, 31(3), 1100–1124.
-#' \url{http://dx.doi.org/10.1137/080736417}.
+#' \url{https://doi.org/10.1137/080736417}.
 #'
 #' @inheritParams bigstatsr-package
 #' @param k Number of singular vectors/values to compute. Default is `10`.

--- a/tmp-save/randomSVD_cpp.R
+++ b/tmp-save/randomSVD_cpp.R
@@ -152,7 +152,7 @@ svds4.seq2 <- function(X., fun.scaling, ind.row, ind.col, k, tol, verbose) {
 #' in Rokhlin, V., Szlam, A., & Tygert, M. (2010).
 #' A Randomized Algorithm for Principal Component Analysis.
 #' SIAM Journal on Matrix Analysis and Applications, 31(3), 1100–1124.
-#' \url{http://dx.doi.org/10.1137/080736417}.
+#' \url{https://doi.org/10.1137/080736417}.
 #'
 #' @inheritParams bigstatsr-package
 #' @param k Number of singular vectors/values to compute. Default is `10`.


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well. Accordingly, this PR updates all DOI links.

Cheers!