### PR TITLE
Add weights feature to linear lasso

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -105,12 +105,12 @@ tcrossprod_mat_FBM <- function(A, BM) {
     .Call(`_bigstatsr_tcrossprod_mat_FBM`, A, BM)
 }
 
-COPY_cdfit_gaussian_hsr <- function(BM, y, row_idx, col_idx, covar, lambda, center, scale, pf, resid, alpha, eps, max_iter, dfmax, row_idx_val, covar_val, y_val, n_abort, nlam_min) {
-    .Call(`_bigstatsr_COPY_cdfit_gaussian_hsr`, BM, y, row_idx, col_idx, covar, lambda, center, scale, pf, resid, alpha, eps, max_iter, dfmax, row_idx_val, covar_val, y_val, n_abort, nlam_min)
+COPY_cdfit_gaussian_hsr <- function(BM, y, row_idx, col_idx, covar, lambda, center, scale, pf, resid, alpha, eps, max_iter, dfmax, row_idx_val, covar_val, y_val, n_abort, nlam_min, weights, weights_val) {
+    .Call(`_bigstatsr_COPY_cdfit_gaussian_hsr`, BM, y, row_idx, col_idx, covar, lambda, center, scale, pf, resid, alpha, eps, max_iter, dfmax, row_idx_val, covar_val, y_val, n_abort, nlam_min, weights, weights_val)
 }
 
-COPY_cdfit_binomial_hsr <- function(BM, y, base, row_idx, col_idx, covar, lambda, center, scale, pf, resid, alpha, eps, max_iter, dfmax, row_idx_val, covar_val, y_val, base_val, n_abort, nlam_min) {
-    .Call(`_bigstatsr_COPY_cdfit_binomial_hsr`, BM, y, base, row_idx, col_idx, covar, lambda, center, scale, pf, resid, alpha, eps, max_iter, dfmax, row_idx_val, covar_val, y_val, base_val, n_abort, nlam_min)
+COPY_cdfit_binomial_hsr <- function(BM, y, base, row_idx, col_idx, covar, lambda, center, scale, pf, resid, alpha, eps, max_iter, dfmax, row_idx_val, covar_val, y_val, base_val, n_abort, nlam_min, weights, weights_val) {
+    .Call(`_bigstatsr_COPY_cdfit_binomial_hsr`, BM, y, base, row_idx, col_idx, covar, lambda, center, scale, pf, resid, alpha, eps, max_iter, dfmax, row_idx_val, covar_val, y_val, base_val, n_abort, nlam_min, weights, weights_val)
 }
 
 bigsummaries <- function(BM, row_idx, col_idx, covar, y, which_set, K) {

--- a/R/biglasso.R
+++ b/R/biglasso.R
@@ -265,7 +265,7 @@ COPY_biglasso_main <- function(X, y.train, ind.train, ind.col, covar.train,
     covar.train[, ind0.covar, drop = FALSE]
   )
   fit <- null_pred(var0.train, y.train, weights, base.train, family)
-  y_diff.train <- y.train - fit$fitted.values
+  y_diff.train <- (y.train - fit$fitted.values)*weights
   base.train <- fit$linear.predictors
   beta0 <- fit$coef[1]
   beta.X <- rep(0, p1)

--- a/R/biglasso.R
+++ b/R/biglasso.R
@@ -194,6 +194,7 @@ COPY_biglasso_part <- function(X, y.train, ind.train, ind.col, covar.train,
 #' @param pf.covar Same as `pf.X`, but for `covar.train`.
 #'   You might want to set some to 0 as variables with large effects can mask
 #'   small effects in penalized regression.
+#' @param weights Observation weights. Default is 1 for each observation
 #'
 #' @keywords internal
 #'

--- a/inst/include/bigstatsr/biglasso/linear.hpp
+++ b/inst/include/bigstatsr/biglasso/linear.hpp
@@ -77,14 +77,13 @@ List COPY_cdfit_gaussian_hsr(C macc,
   nb_active[0] = nb_candidate[0] = iter[0] = 0;
   loss[0] = COPY_gLoss(r);
   thresh = eps * loss[0] / n;
-  metrics[0] = metric_min = COPY_gLoss(y_val);
 
   NumericVector pred_val_w(n_val);
   NumericVector y_val_w(n_val);
   for (int i = 0; i < n_val; i++) {
     y_val_w[i] = y_val[i] * weights_val[i];
   }
-
+  metrics[0] = metric_min = COPY_gLoss(y_val_w);
   // Path
   for (int l = 1; l < L; l++) {
 

--- a/inst/include/bigstatsr/biglasso/logistic.hpp
+++ b/inst/include/bigstatsr/biglasso/logistic.hpp
@@ -46,7 +46,9 @@ List COPY_cdfit_binomial_hsr(C macc,
                              const NumericVector& y_val,
                              const NumericVector& base_val,
                              int n_abort,
-                             int nlam_min) {
+                             int nlam_min,
+                             const NumericVector& weights,
+                             const NumericVector& weights_val) {
 
   size_t n = macc.nrow(); // number of observations used for fitting model
   size_t p = macc.ncol();
@@ -210,7 +212,7 @@ List COPY_cdfit_binomial_hsr(C macc,
       // Scan for violations in strong set
       // Rcout << (Rcpp::sum(s) == sum_s) << std::endl;
       violations = COPY_check_strong_set(
-        in_A, in_S, z, macc, center, scale, pf, beta_old, l1, l2, s, sum_s);
+        in_A, in_S, z, macc, center, scale, pf, beta_old, l1, l2, s, sum_s, weights);
       if (violations == 0) break;
     }
 

--- a/inst/include/bigstatsr/biglasso/utils.hpp
+++ b/inst/include/bigstatsr/biglasso/utils.hpp
@@ -101,7 +101,8 @@ size_t COPY_check_strong_set(LogicalVector& in_A,
                              const NumericVector& beta_old,
                              double l1, double l2,
                              const NumericVector& r,
-                             double sumResid) {
+                             double sumResid,
+                             const NumericVector& weights) {
 
   size_t n = macc.nrow();
   size_t p = macc.ncol();
@@ -111,7 +112,7 @@ size_t COPY_check_strong_set(LogicalVector& in_A,
     if (in_S[j] && !in_A[j]) {
       double cpsum = 0;
       for (i = 0; i < n; i++) {
-        cpsum += macc(i, j) * r[i];
+        cpsum += macc(i, j) * r[i] * weights[i];
       }
       z[j] = (cpsum - center[j] * sumResid) / (scale[j] * n);
 

--- a/man/COPY_biglasso_main.Rd
+++ b/man/COPY_biglasso_main.Rd
@@ -27,7 +27,8 @@ COPY_biglasso_main(
   lambda.min = if (n > p) 1e-04 else 0.001,
   return.all = FALSE,
   warn = TRUE,
-  ncores = 1
+  ncores = 1,
+  weights = NULL
 )
 }
 \arguments{
@@ -91,6 +92,8 @@ now deprecated.}
 
 \item{warn}{Whether to warn if some models may not have reached a minimum.
 Default is \code{TRUE}.}
+
+\item{weights}{Observation weights. Default is 1 for each observation}
 }
 \description{
 Fit solution paths for linear or logistic regression models penalized by

--- a/man/COPY_biglasso_part.Rd
+++ b/man/COPY_biglasso_part.Rd
@@ -26,7 +26,9 @@ COPY_biglasso_part(
   nlam.min,
   base.train,
   base.val,
-  pf
+  pf,
+  weights.train,
+  weights.val
 )
 }
 \value{

--- a/man/big_spLinReg.Rd
+++ b/man/big_spLinReg.Rd
@@ -22,6 +22,7 @@ big_spLinReg(
   dfmax = 50000,
   warn = TRUE,
   ncores = 1,
+  weights = NULL,
   ...
 )
 }
@@ -87,6 +88,8 @@ Default is \code{TRUE}.}
 
 \item{ncores}{Number of cores used. Default doesn't use parallelism.
 You may use \link{nb_cores}.}
+
+\item{weights}{Observation weights. Default is 1 for each observation}
 
 \item{...}{
   Arguments passed on to \code{\link[=COPY_biglasso_main]{COPY_biglasso_main}}

--- a/man/big_spLogReg.Rd
+++ b/man/big_spLogReg.Rd
@@ -22,6 +22,7 @@ big_spLogReg(
   dfmax = 50000,
   warn = TRUE,
   ncores = 1,
+  weights = NULL,
   ...
 )
 }
@@ -88,6 +89,8 @@ Default is \code{TRUE}.}
 
 \item{ncores}{Number of cores used. Default doesn't use parallelism.
 You may use \link{nb_cores}.}
+
+\item{weights}{Observation weights. Default is 1 for each observation}
 
 \item{...}{
   Arguments passed on to \code{\link[=COPY_biglasso_main]{COPY_biglasso_main}}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -338,8 +338,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // COPY_cdfit_gaussian_hsr
-List COPY_cdfit_gaussian_hsr(Environment BM, const NumericVector& y, const IntegerVector& row_idx, const IntegerVector& col_idx, const NumericMatrix& covar, const NumericVector& lambda, const NumericVector& center, const NumericVector& scale, const NumericVector& pf, NumericVector& resid, double alpha, double eps, int max_iter, int dfmax, const IntegerVector& row_idx_val, const NumericMatrix& covar_val, const NumericVector& y_val, int n_abort, int nlam_min);
-RcppExport SEXP _bigstatsr_COPY_cdfit_gaussian_hsr(SEXP BMSEXP, SEXP ySEXP, SEXP row_idxSEXP, SEXP col_idxSEXP, SEXP covarSEXP, SEXP lambdaSEXP, SEXP centerSEXP, SEXP scaleSEXP, SEXP pfSEXP, SEXP residSEXP, SEXP alphaSEXP, SEXP epsSEXP, SEXP max_iterSEXP, SEXP dfmaxSEXP, SEXP row_idx_valSEXP, SEXP covar_valSEXP, SEXP y_valSEXP, SEXP n_abortSEXP, SEXP nlam_minSEXP) {
+List COPY_cdfit_gaussian_hsr(Environment BM, const NumericVector& y, const IntegerVector& row_idx, const IntegerVector& col_idx, const NumericMatrix& covar, const NumericVector& lambda, const NumericVector& center, const NumericVector& scale, const NumericVector& pf, NumericVector& resid, double alpha, double eps, int max_iter, int dfmax, const IntegerVector& row_idx_val, const NumericMatrix& covar_val, const NumericVector& y_val, int n_abort, int nlam_min, const NumericVector& weights, const NumericVector& weights_val);
+RcppExport SEXP _bigstatsr_COPY_cdfit_gaussian_hsr(SEXP BMSEXP, SEXP ySEXP, SEXP row_idxSEXP, SEXP col_idxSEXP, SEXP covarSEXP, SEXP lambdaSEXP, SEXP centerSEXP, SEXP scaleSEXP, SEXP pfSEXP, SEXP residSEXP, SEXP alphaSEXP, SEXP epsSEXP, SEXP max_iterSEXP, SEXP dfmaxSEXP, SEXP row_idx_valSEXP, SEXP covar_valSEXP, SEXP y_valSEXP, SEXP n_abortSEXP, SEXP nlam_minSEXP, SEXP weightsSEXP, SEXP weights_valSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -362,13 +362,15 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const NumericVector& >::type y_val(y_valSEXP);
     Rcpp::traits::input_parameter< int >::type n_abort(n_abortSEXP);
     Rcpp::traits::input_parameter< int >::type nlam_min(nlam_minSEXP);
-    rcpp_result_gen = Rcpp::wrap(COPY_cdfit_gaussian_hsr(BM, y, row_idx, col_idx, covar, lambda, center, scale, pf, resid, alpha, eps, max_iter, dfmax, row_idx_val, covar_val, y_val, n_abort, nlam_min));
+    Rcpp::traits::input_parameter< const NumericVector& >::type weights(weightsSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type weights_val(weights_valSEXP);
+    rcpp_result_gen = Rcpp::wrap(COPY_cdfit_gaussian_hsr(BM, y, row_idx, col_idx, covar, lambda, center, scale, pf, resid, alpha, eps, max_iter, dfmax, row_idx_val, covar_val, y_val, n_abort, nlam_min, weights, weights_val));
     return rcpp_result_gen;
 END_RCPP
 }
 // COPY_cdfit_binomial_hsr
-List COPY_cdfit_binomial_hsr(Environment BM, const NumericVector& y, const NumericVector& base, const IntegerVector& row_idx, const IntegerVector& col_idx, const NumericMatrix& covar, const NumericVector& lambda, const NumericVector& center, const NumericVector& scale, const NumericVector& pf, NumericVector& resid, double alpha, double eps, int max_iter, int dfmax, const IntegerVector& row_idx_val, const NumericMatrix& covar_val, const NumericVector& y_val, const NumericVector& base_val, int n_abort, int nlam_min);
-RcppExport SEXP _bigstatsr_COPY_cdfit_binomial_hsr(SEXP BMSEXP, SEXP ySEXP, SEXP baseSEXP, SEXP row_idxSEXP, SEXP col_idxSEXP, SEXP covarSEXP, SEXP lambdaSEXP, SEXP centerSEXP, SEXP scaleSEXP, SEXP pfSEXP, SEXP residSEXP, SEXP alphaSEXP, SEXP epsSEXP, SEXP max_iterSEXP, SEXP dfmaxSEXP, SEXP row_idx_valSEXP, SEXP covar_valSEXP, SEXP y_valSEXP, SEXP base_valSEXP, SEXP n_abortSEXP, SEXP nlam_minSEXP) {
+List COPY_cdfit_binomial_hsr(Environment BM, const NumericVector& y, const NumericVector& base, const IntegerVector& row_idx, const IntegerVector& col_idx, const NumericMatrix& covar, const NumericVector& lambda, const NumericVector& center, const NumericVector& scale, const NumericVector& pf, NumericVector& resid, double alpha, double eps, int max_iter, int dfmax, const IntegerVector& row_idx_val, const NumericMatrix& covar_val, const NumericVector& y_val, const NumericVector& base_val, int n_abort, int nlam_min, const NumericVector& weights, const NumericVector& weights_val);
+RcppExport SEXP _bigstatsr_COPY_cdfit_binomial_hsr(SEXP BMSEXP, SEXP ySEXP, SEXP baseSEXP, SEXP row_idxSEXP, SEXP col_idxSEXP, SEXP covarSEXP, SEXP lambdaSEXP, SEXP centerSEXP, SEXP scaleSEXP, SEXP pfSEXP, SEXP residSEXP, SEXP alphaSEXP, SEXP epsSEXP, SEXP max_iterSEXP, SEXP dfmaxSEXP, SEXP row_idx_valSEXP, SEXP covar_valSEXP, SEXP y_valSEXP, SEXP base_valSEXP, SEXP n_abortSEXP, SEXP nlam_minSEXP, SEXP weightsSEXP, SEXP weights_valSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -393,7 +395,9 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const NumericVector& >::type base_val(base_valSEXP);
     Rcpp::traits::input_parameter< int >::type n_abort(n_abortSEXP);
     Rcpp::traits::input_parameter< int >::type nlam_min(nlam_minSEXP);
-    rcpp_result_gen = Rcpp::wrap(COPY_cdfit_binomial_hsr(BM, y, base, row_idx, col_idx, covar, lambda, center, scale, pf, resid, alpha, eps, max_iter, dfmax, row_idx_val, covar_val, y_val, base_val, n_abort, nlam_min));
+    Rcpp::traits::input_parameter< const NumericVector& >::type weights(weightsSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type weights_val(weights_valSEXP);
+    rcpp_result_gen = Rcpp::wrap(COPY_cdfit_binomial_hsr(BM, y, base, row_idx, col_idx, covar, lambda, center, scale, pf, resid, alpha, eps, max_iter, dfmax, row_idx_val, covar_val, y_val, base_val, n_abort, nlam_min, weights, weights_val));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -634,8 +638,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_bigstatsr_tcrossprod_FBM", (DL_FUNC) &_bigstatsr_tcrossprod_FBM, 1},
     {"_bigstatsr_tcrossprod_FBM_mat", (DL_FUNC) &_bigstatsr_tcrossprod_FBM_mat, 2},
     {"_bigstatsr_tcrossprod_mat_FBM", (DL_FUNC) &_bigstatsr_tcrossprod_mat_FBM, 2},
-    {"_bigstatsr_COPY_cdfit_gaussian_hsr", (DL_FUNC) &_bigstatsr_COPY_cdfit_gaussian_hsr, 19},
-    {"_bigstatsr_COPY_cdfit_binomial_hsr", (DL_FUNC) &_bigstatsr_COPY_cdfit_binomial_hsr, 21},
+    {"_bigstatsr_COPY_cdfit_gaussian_hsr", (DL_FUNC) &_bigstatsr_COPY_cdfit_gaussian_hsr, 21},
+    {"_bigstatsr_COPY_cdfit_binomial_hsr", (DL_FUNC) &_bigstatsr_COPY_cdfit_binomial_hsr, 23},
     {"_bigstatsr_bigsummaries", (DL_FUNC) &_bigstatsr_bigsummaries, 7},
     {"_bigstatsr_bigcolvars", (DL_FUNC) &_bigstatsr_bigcolvars, 3},
     {"_bigstatsr_mycount1", (DL_FUNC) &_bigstatsr_mycount1, 4},

--- a/src/biglassoLin.cpp
+++ b/src/biglassoLin.cpp
@@ -10,7 +10,7 @@ using namespace Rcpp;
 #define CALL_COPY_CDFIT_GAUSSIAN_HSR(ACC, ACC_VAL) {                           \
   return bigstatsr::biglassoLin::COPY_cdfit_gaussian_hsr(ACC, y,               \
     lambda, center, scale, pf, resid, alpha, eps, max_iter, dfmax,             \
-    ACC_VAL, y_val, n_abort, nlam_min);                                        \
+    ACC_VAL, y_val, n_abort, nlam_min, weights, weights_val);                                        \
 }
 
 // Dispatch function for COPY_cdfit_gaussian_hsr
@@ -33,7 +33,9 @@ List COPY_cdfit_gaussian_hsr(Environment BM,
                              const NumericMatrix& covar_val,
                              const NumericVector& y_val,
                              int n_abort,
-                             int nlam_min) {
+                             int nlam_min,
+                             const NumericVector& weights,
+                             const NumericVector& weights_val) {
 
   DISPATCH_SUBMATCOVACC_VAL(CALL_COPY_CDFIT_GAUSSIAN_HSR)
 }

--- a/src/biglassoLog.cpp
+++ b/src/biglassoLog.cpp
@@ -10,7 +10,7 @@ using namespace Rcpp;
 #define CALL_COPY_CDFIT_BINOMIAL_HSR(ACC, ACC_VAL) {                           \
   return bigstatsr::biglassoLog::COPY_cdfit_binomial_hsr(ACC, y, base,         \
     lambda, center, scale, pf, resid, alpha, eps, max_iter, dfmax,             \
-    ACC_VAL, y_val, base_val, n_abort, nlam_min);                              \
+    ACC_VAL, y_val, base_val, n_abort, nlam_min, weights, weights_val);                              \
 }
 
 // Dispatch function for COPY_cdfit_binomial_hsr
@@ -35,7 +35,9 @@ List COPY_cdfit_binomial_hsr(Environment BM,
                              const NumericVector& y_val,
                              const NumericVector& base_val,
                              int n_abort,
-                             int nlam_min) {
+                             int nlam_min,
+                             const NumericVector& weights,
+                             const NumericVector& weights_val) {
 
   DISPATCH_SUBMATCOVACC_VAL(CALL_COPY_CDFIT_BINOMIAL_HSR)
 }


### PR DESCRIPTION
Following #76, I've added a sample weights argument to big_spLinReg and subsequent downstream functions. In the cross-validation step, this gets split into weights.train and weights.val for the training and validation sets respectively.

The main change is that the residuals r[i] need to be multiplied by the corresponding weight. This happens when computing sumResid (no longer always zero) and to compute the z[j]. (The code is mostly borrowed/inspired from the logistic.hpp since this is effectively implementing a reweighted LASSO anyway!)

weights.val is just used to reweight the validation sample values y_val and the predicted values pred_val.